### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/zkz098/frontmatter-editor/security/code-scanning/1](https://github.com/zkz098/frontmatter-editor/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow file. This can be done at the top level (applies to all jobs) or at the job level (applies only to the specified job). The minimal starting point is `contents: read`, which allows the workflow to read repository contents but not write to them. If any step in the workflow requires additional permissions (such as creating releases or uploading artifacts to GitHub Releases), those should be added as needed. In this workflow, the `tauri-apps/tauri-action` step may require `contents: write` if it is configured to create releases, but as those lines are commented out, the minimal permission of `contents: read` is sufficient for now.

The change should be made near the top of the file, after the `name` and `on` keys, but before `jobs:`. No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
